### PR TITLE
[FE] Eslint/Prettier 적용, Button 컴포넌트 생성

### DIFF
--- a/client/kiri/.eslintignore
+++ b/client/kiri/.eslintignore
@@ -1,0 +1,5 @@
+/node_modules
+/build
+/config
+/scripts
+src/GlobalStyle.js

--- a/client/kiri/.eslintrc.json
+++ b/client/kiri/.eslintrc.json
@@ -1,0 +1,40 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:import/recommended",
+    "plugin:jsx-a11y/recommended",
+    "plugin:prettier/recommended"
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "react/react-in-jsx-scope": 0,
+    "react/jsx-uses-react": 0,
+    "prettier/prettier": "error",
+    "react/prop-types": 0,
+    "jsx-a11y/label-has-associated-control": [
+      2,
+      {
+        "labelAttributes": ["htmlFor"]
+      }
+    ]
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "moduleDirectory": ["node_modules", "src/"]
+      }
+    }
+  }
+}

--- a/client/kiri/.prettierignore
+++ b/client/kiri/.prettierignore
@@ -1,0 +1,4 @@
+/node_modules
+/build
+/config
+/scripts

--- a/client/kiri/.prettierrc.json
+++ b/client/kiri/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "useTabs": false,
+  "tabWidth": 2,
+  "printWidth": 80
+}

--- a/client/kiri/package-lock.json
+++ b/client/kiri/package-lock.json
@@ -11,6 +11,8 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.7.1",
@@ -19,6 +21,10 @@
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.6",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "eslint": "^8.29.0",
+        "prettier": "2.8.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7049,9 +7055,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
+      "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.11.6",
@@ -7101,6 +7107,17 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-react-app": {
@@ -7293,6 +7310,26 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -7851,6 +7888,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -13859,6 +13901,31 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -22189,9 +22256,9 @@
       }
     },
     "eslint": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
+      "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.11.6",
@@ -22309,6 +22376,12 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "7.0.1",
@@ -22453,6 +22526,14 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -22772,6 +22853,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -26911,6 +26997,19 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "prettier": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg=="
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/client/kiri/package.json
+++ b/client/kiri/package.json
@@ -6,6 +6,8 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.7.1",
@@ -38,5 +40,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "eslint": "^8.29.0",
+    "prettier": "2.8.1"
   }
 }

--- a/client/kiri/src/Components/Buttons.js
+++ b/client/kiri/src/Components/Buttons.js
@@ -6,7 +6,7 @@ const Button1Container = styled.button`
   font-size: ${(props) => props.fontSize || '14px'};
   border-radius: 6px;
   border: none;
-  color: ${({ theme }) => theme.colors.darkgray};
+  color: #4c695d;
   font-weight: 700;
   background-color: ${({ theme }) => theme.colors.green_2};
   &:hover {
@@ -27,7 +27,7 @@ const Button2Container = styled.button`
     cursor: pointer;
     background-color: ${({ theme }) => theme.colors.green_2};
     border: none;
-    color: ${({ theme }) => theme.colors.darkgray};
+    color: #4c695d;
   }
 `;
 

--- a/client/kiri/src/Components/Buttons.js
+++ b/client/kiri/src/Components/Buttons.js
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+const Button1Container = styled.button`
+  width: ${(props) => props.width || '80px'};
+  height: ${(props) => props.height || '30px'};
+  font-size: ${(props) => props.fontSize || '14px'};
+  border-radius: 6px;
+  border: none;
+  color: ${({ theme }) => theme.colors.darkgray};
+  font-weight: 700;
+  background-color: ${({ theme }) => theme.colors.green_2};
+  &:hover {
+    cursor: pointer;
+    background-color: ${({ theme }) => theme.colors.green_1};
+  }
+`;
+
+const Button2Container = styled.button`
+  width: ${(props) => props.width || '80px'};
+  height: ${(props) => props.height || '30px'};
+  border-radius: 6px;
+  border: 2px solid ${({ theme }) => theme.colors.mainColor};
+  color: ${({ theme }) => theme.colors.mainColor};
+  font-weight: 700;
+  background-color: white;
+  &:hover {
+    cursor: pointer;
+    background-color: ${({ theme }) => theme.colors.green_2};
+    border: none;
+    color: ${({ theme }) => theme.colors.darkgray};
+  }
+`;
+
+const Button_1 = ({ children, ...props }) => {
+  return <Button1Container {...props}>{children}</Button1Container>;
+};
+
+const Button_2 = ({ children, ...props }) => {
+  return <Button2Container {...props}>{children}</Button2Container>;
+};
+
+export { Button_1, Button_2 };

--- a/client/kiri/src/Components/Footer.js
+++ b/client/kiri/src/Components/Footer.js
@@ -1,7 +1,5 @@
-import React from 'react';
 import { SiGithub } from 'react-icons/si';
 import styled from 'styled-components';
-
 
 const Foot = styled.footer`
   display: flex;
@@ -19,13 +17,13 @@ const Foot = styled.footer`
     padding-right: 10px;
     border-right: solid 2px rgb(99, 99, 99);
   }
-  
-  p{
+
+  p {
     text-align: left;
     color: rgb(99, 99, 99);
   }
 
-  p span{
+  p span {
     display: inline-block;
     margin-left: 20px;
     font-weight: bold;
@@ -33,18 +31,30 @@ const Foot = styled.footer`
 
   p span a {
     text-decoration-line: none;
-    color:rgb(99, 99, 99);
+    color: rgb(99, 99, 99);
   }
 `;
 
 export const Footer = () => {
   return (
     <Foot>
-      <img id="logo" src={`${process.env.PUBLIC_URL}/kiri_logo.png`} width="70" height="70"/>
+      <img
+        id="logo"
+        src={`${process.env.PUBLIC_URL}/kiri_logo.png`}
+        width="70"
+        height="70"
+        alt="logo"
+      />
       <p>
         <span>
           <SiGithub href="https://github.com/Jeans-ssu/Kiri" />{' '}
-          <a href="https://github.com/Jeans-ssu/Kiri" target="_blank" rel="noreferrer">Github</a>
+          <a
+            href="https://github.com/Jeans-ssu/Kiri"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Github
+          </a>
         </span>
         <br />
         <span>Made by: 정노은, 김수진, 김정우</span>

--- a/client/kiri/src/containers/PageContainer.js
+++ b/client/kiri/src/containers/PageContainer.js
@@ -13,7 +13,7 @@ const ContentContainer = styled.div`
   flex: 1;
   width: 100%;
   max-width: 1024px;
-  min-width: 500px;
+  min-width: 375px;
 `;
 
 //TODO: 헤더, 푸터 추가

--- a/client/kiri/src/containers/PageContainer.js
+++ b/client/kiri/src/containers/PageContainer.js
@@ -1,6 +1,6 @@
 import styled, { ThemeProvider } from 'styled-components';
 import theme from 'styles/theme';
-import { Footer } from 'Components/Footer';
+import { Footer } from 'components/Footer';
 
 const PageContainerBox = styled.div`
   min-height: 100vh;

--- a/client/kiri/src/styles/theme.js
+++ b/client/kiri/src/styles/theme.js
@@ -2,7 +2,7 @@ const colors = {
   mainColor: '#47DA9C',
   green_1: '#86DDB8',
   green_2: '#BEEEDA',
-  green_3: '59B89D',
+  green_3: '#59B89D',
   dark: '#232627',
   darkgray: '#434343',
   gray: '#737373',

--- a/client/kiri/src/styles/theme.js
+++ b/client/kiri/src/styles/theme.js
@@ -2,11 +2,14 @@ const colors = {
   mainColor: '#47DA9C',
   green_1: '#86DDB8',
   green_2: '#BEEEDA',
+  green_3: '59B89D',
   dark: '#232627',
   darkgray: '#434343',
   gray: '#737373',
   lightgray: '#BFBFBF',
   light: '#f5f5f5',
+  purple: '#9B90E6',
+  yellow: '#FFCF70',
 };
 
 const theme = {


### PR DESCRIPTION
## 📌 작업사항
- Eslint, Prettier 설치 및 적용
- theme에 color 추가 (피그마 프로토타입에 컬러칩있음!!)
- pageContainer minWidth 375px로 변경(아이폰 SE)
- 버튼 컴포넌트 2개 제작

## 💌 참고사항
- 버튼 컴포넌트는 src/components/Button
- **npm i** 필요!!

## 📸 스크린샷
![버튼](https://user-images.githubusercontent.com/70098708/207050144-3e43b63d-e3f8-4b18-819e-6ef018b1765e.gif)