### PR TITLE
[FE] redux-persist 도입

### DIFF
--- a/client/kiri/package-lock.json
+++ b/client/kiri/package-lock.json
@@ -26,6 +26,7 @@
         "react-slick": "^0.29.0",
         "redux-devtools-extension": "^2.13.9",
         "redux-logger": "^3.0.6",
+        "redux-persist": "^6.0.0",
         "slick-carousel": "^1.8.1",
         "styled-components": "^5.3.6",
         "web-vitals": "^2.1.4"
@@ -14685,6 +14686,14 @@
         "deep-diff": "^0.3.5"
       }
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
@@ -27793,6 +27802,12 @@
       "requires": {
         "deep-diff": "^0.3.5"
       }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "2.4.2",

--- a/client/kiri/package.json
+++ b/client/kiri/package.json
@@ -21,6 +21,7 @@
     "react-slick": "^0.29.0",
     "redux-devtools-extension": "^2.13.9",
     "redux-logger": "^3.0.6",
+    "redux-persist": "^6.0.0",
     "slick-carousel": "^1.8.1",
     "styled-components": "^5.3.6",
     "web-vitals": "^2.1.4"

--- a/client/kiri/src/index.js
+++ b/client/kiri/src/index.js
@@ -1,14 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { store } from 'store/store';
+import { store, persistor } from 'store/store';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+
 root.render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <PersistGate loading={null} persistor={persistor}>
+        <App />
+      </PersistGate>
     </Provider>
   </React.StrictMode>
 );

--- a/client/kiri/src/store/modules/authSlice.js
+++ b/client/kiri/src/store/modules/authSlice.js
@@ -1,0 +1,15 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  isLogin: false,
+  nickName: '',
+  email: '',
+};
+
+export const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {},
+});
+
+export default authSlice.reducer;

--- a/client/kiri/src/store/store.js
+++ b/client/kiri/src/store/store.js
@@ -1,13 +1,28 @@
-import { combineReducers } from '@reduxjs/toolkit';
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import counterReducer from '../store/modules/counterSlice';
+import { persistReducer, persistStore } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
+import authReducer from './modules/authSlice';
+
+const persistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['auth'],
+};
 
 export const rootReducer = combineReducers({
   counter: counterReducer,
+  auth: authReducer,
 });
 
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
 export const store = configureStore({
-  reducer: {
-    counter: counterReducer,
-  },
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
 });
+
+export const persistor = persistStore(store);

--- a/client/kiri/src/store/store.js
+++ b/client/kiri/src/store/store.js
@@ -6,8 +6,8 @@ import authReducer from './modules/authSlice';
 
 const persistConfig = {
   key: 'root',
-  storage,
-  whitelist: ['auth'],
+  storage, //local Storage에 저장
+  whitelist: ['auth'], //auth Reducer만 저장
 };
 
 export const rootReducer = combineReducers({
@@ -25,4 +25,5 @@ export const store = configureStore({
     }),
 });
 
+//src/index.js에서 PersistGate 사용을 위한 persistor
 export const persistor = persistStore(store);


### PR DESCRIPTION
## 📌 작업사항
- redux-persist 도입
새로고침하면 redux storage 정보가 초기화되기 때문에 redux-persist 이용해서 localStorage에 auth 관련 정보만 저장하게끔

## 💌 참고사항
- npm install 필요!
참고링크
- https://blog.logrocket.com/persist-state-redux-persist-redux-toolkit-react/
- https://kyounghwan01.github.io/blog/React/redux/redux-persist/#%E1%84%89%E1%85%A9%E1%84%80%E1%85%A2-%E1%84%89%E1%85%A1%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%92%E1%85%A1%E1%84%82%E1%85%B3%E1%86%AB-%E1%84%8B%E1%85%B5%E1%84%8B%E1%85%B2

## 📸 스크린샷
