### PR TITLE
[FE] 태그 UI 구현

### DIFF
--- a/client/kiri/src/components/ImgBox.js
+++ b/client/kiri/src/components/ImgBox.js
@@ -58,7 +58,7 @@ const ImgBox = ({ el, idx, deleteImg, imageUrl }) => {
       </TopBox>
       <BottomBox>
         <OcrBox>
-          <OcrBtn onClick={analyzeImage}>OCR 하기</OcrBtn>
+          <OcrBtn onClick={analyzeImage}>자동 입력 하기</OcrBtn>
         </OcrBox>
       </BottomBox>
     </GridBox>
@@ -71,9 +71,26 @@ const TopBox = styled.div`
 
 const BottomBox = styled.div``;
 
-const OcrBox = styled.div``;
+const OcrBox = styled.div`
+  width: 135px;
+  @media screen and (max-width: 767px) {
+    width: 100px;
+  }
+`;
 
-const OcrBtn = styled.div``;
+const OcrBtn = styled.div`
+  color: #759cff;
+  font-weight: 600;
+  text-align: center;
+  margin-top: 10px;
+  &:hover {
+    cursor: pointer;
+    color: #4f80ff;
+  }
+  @media screen and (max-width: 767px) {
+    font-size: 14px;
+  }
+`;
 
 const GridBox = styled.div`
   display: flex;

--- a/client/kiri/src/pages/EventWrite/EventTagInput.js
+++ b/client/kiri/src/pages/EventWrite/EventTagInput.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { useState } from 'react';
 
 export const EventTagInput = () => {
-  const [tagList, setTagList] = useState(['인공지능', '강연']);
+  const [tagList, setTagList] = useState([]);
   const [tagInput, setTagInput] = useState('');
 
   const handleChangeTagInput = (e) => {

--- a/client/kiri/src/pages/EventWrite/EventTagInput.js
+++ b/client/kiri/src/pages/EventWrite/EventTagInput.js
@@ -1,0 +1,107 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+
+export const EventTagInput = () => {
+  const [tagList, setTagList] = useState(['인공지능', '강연']);
+  const [tagInput, setTagInput] = useState('');
+
+  const handleChangeTagInput = (e) => {
+    setTagInput(e.target.value);
+  };
+
+  const handleOnKeyPress = (e) => {
+    if (e.key === 'Enter' && tagList.length <= 4) {
+      if (tagInput !== '') {
+        setTagList([...tagList, tagInput]);
+        setTagInput('');
+      }
+    }
+  };
+
+  const handleClickTag = (item) => {
+    const filteredTagList = tagList.filter((el) => {
+      return el !== item;
+    });
+    setTagList(filteredTagList);
+  };
+
+  return (
+    <EventTagInputContainer>
+      <TagHeader>태그</TagHeader>
+      <TagsContainer>
+        <TagInput
+          placeholder="태그를 입력하세요"
+          maxLength={15}
+          value={tagInput}
+          onChange={handleChangeTagInput}
+          onKeyPress={handleOnKeyPress}
+        />
+        {tagList.map((el, idx) => {
+          return (
+            <Tag
+              key={idx}
+              onClick={() => {
+                handleClickTag(el);
+              }}
+            >
+              {el}
+            </Tag>
+          );
+        })}
+      </TagsContainer>
+    </EventTagInputContainer>
+  );
+};
+
+const EventTagInputContainer = styled.div`
+  display: flex;
+  margin-bottom: 15px;
+  @media screen and (max-width: 767px) {
+    margin: 15px auto 5px;
+    width: 90%;
+  }
+`;
+
+const TagHeader = styled.div`
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.dark};
+  width: 70px;
+  margin-top: 7px;
+`;
+
+const TagsContainer = styled.div`
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  min-height: 40px;
+`;
+
+const TagInput = styled.input`
+  border: none;
+  background-color: transparent;
+  &:focus {
+    outline: none;
+  }
+  width: 120px;
+  padding-bottom: 10px;
+`;
+
+const Tag = styled.button`
+  background-color: ${({ theme }) => theme.colors.light};
+  color: ${({ theme }) => theme.colors.darkgray};
+  border: 1px solid ${({ theme }) => theme.colors.mainColor};
+
+  padding: 5px 10px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  font-size: 14px;
+  border-radius: 15px;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  @media screen and (max-width: 767px) {
+    font-size: 12px;
+  }
+`;

--- a/client/kiri/src/pages/EventWrite/EventWritePage.js
+++ b/client/kiri/src/pages/EventWrite/EventWritePage.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import EventTitleInput from './EventTitleInput';
 import EventInfoInput from './EventInfoInput';
 import EventExplainInput from './EventExplainInput';
+import { EventTagInput } from './EventTagInput';
 import EventEtcInput from './EventEtcInput';
 import axios from '../../api/axios';
 import { selectAccessToken } from 'store/modules/authSlice';
@@ -291,6 +292,7 @@ const EventWritePage = () => {
           explainRef={explainRef}
           errorMessage={errorMessage}
         />
+        <EventTagInput />
         <EventEtcInput
           link={link}
           setLink={setLink}


### PR DESCRIPTION
## 📌 작업사항
- 이벤트 작성 시 태그 UI 구현 (최대 5개, 빈 문자열은 입력 불가)
- OCR하기 버튼 디자인 수정

## 💌 참고사항

## 📸 스크린샷
<img width="975" alt="image" src="https://github.com/Jeans-ssu/Kiri/assets/70098708/d44aeb27-fcfb-4391-a143-d97036e6426f">