### PR TITLE
🐛 [FE] fix: 검색페이지에서 새로고침해도 정보 유지

### DIFF
--- a/client/kiri/src/pages/Event/EventSearchPage.js
+++ b/client/kiri/src/pages/Event/EventSearchPage.js
@@ -1,10 +1,6 @@
 import styled from 'styled-components';
 import PageContainer from 'containers/PageContainer';
-import {
-  selectSearchMode,
-  selectSearchWord,
-  setSearchMode,
-} from 'store/modules/searchSlice';
+import { selectSearchMode, setSearchMode } from 'store/modules/searchSlice';
 import { useSelector, useDispatch } from 'react-redux';
 import axios from '../../api/axios';
 import { useEffect, useState } from 'react';
@@ -13,7 +9,6 @@ import EventContent from './EventContent';
 
 const EventSearchPage = () => {
   const [data, setData] = useState([]);
-  const searchWord = useSelector(selectSearchWord);
   const searchMode = useSelector(selectSearchMode);
 
   const { searchWordParam } = useParams();
@@ -26,7 +21,7 @@ const EventSearchPage = () => {
 
   async function getSearch() {
     await axios
-      .get(`/posts/search?relation=${searchWord}`)
+      .get(`/posts/search?relation=${searchWordParam}`)
       .then((res) => {
         setData(res.data);
         dispatch(setSearchMode(false));


### PR DESCRIPTION
## 📌 작업사항
검색 페이지에서 새로고침 하였을때 정보 유지되도록

## 💌 참고사항


## 📸 스크린샷
검색 후 새로고침 하기 전
![image](https://github.com/Jeans-ssu/Kiri/assets/58413633/022e5e7f-739d-491d-85be-e72595ab02d9)


새로고침 후
![image](https://github.com/Jeans-ssu/Kiri/assets/58413633/586810a2-7067-48f7-b528-3814b5ae78f8)
